### PR TITLE
Update epoll dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/natevw/pi-pins",
   "dependencies": {
-    "epoll": "^0.1.3"
+    "epoll": "^2.0.7"
   }
 }


### PR DESCRIPTION
I had issues with the older version of epoll, therefore updated the dependency. Could this be integrated back into the main repository and released to NPM? Thanks